### PR TITLE
Fix previous/next article footer width spacing on mobile

### DIFF
--- a/layouts/PostLayout.tsx
+++ b/layouts/PostLayout.tsx
@@ -142,9 +142,9 @@ export default function PostLayout({ content, authorDetails, next, prev, childre
                     </div>
                   )}
                   {(next || prev) && (
-                    <div className="flex justify-between py-4 xl:block xl:space-y-8 xl:py-8">
+                    <div className="flex justify-between gap-4 py-4 xl:block xl:space-y-8 xl:py-8">
                       {prev && prev.path && (
-                        <div>
+                        <div className="w-full sm:w-[48%] xl:w-auto">
                           <h2 className="text-xs tracking-wide text-gray-500 uppercase dark:text-gray-400">
                             Previous Article
                           </h2>


### PR DESCRIPTION
Add width spacing between previous and next article in the footer. On mobile, the titles have no spacing.

<img src="https://github.com/user-attachments/assets/a5171d60-d672-42be-9d0c-5ae16d62bb2e" width="400">

<img src="https://github.com/user-attachments/assets/e6d21f96-e58c-4279-9225-dc282c7f0329" width="400">
